### PR TITLE
Feat: 블록 1개를 전달하는 함수 (Wit AI)

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,8 @@ const cors = require("cors");
 const connectDB = require("./database/connection");
 
 const index = require("./routes/index");
+const testCodes = require("./routes/testCodes");
+const inputForm = require("./routes/inputForm");
 
 const app = express();
 
@@ -31,6 +33,8 @@ app.use(
 );
 
 app.use("/", index);
+app.use("/input", inputForm);
+app.use("/test-codes", testCodes);
 
 app.use((req, res, next) => {
   next(createError(404));

--- a/middlewares/blockConverter.js
+++ b/middlewares/blockConverter.js
@@ -1,0 +1,24 @@
+const { Wit } = require("node-wit");
+
+const client = new Wit({
+  accessToken: process.env.WIT_AI_SERVER_ACCESS_TOKEN,
+});
+
+const convertBlocksToTestCode = async (req, res, next) => {
+  try {
+    const userInput = req.body.inputData;
+    console.log("입력한 input 값", userInput);
+
+    const response = await client.message(userInput, {});
+
+    console.log("wit.ai의 응답", response);
+
+    res.locals.testCode = response;
+    next();
+  } catch (error) {
+    console.error("error:", error);
+    next(error);
+  }
+};
+
+module.exports = convertBlocksToTestCode;

--- a/routes/inputForm.js
+++ b/routes/inputForm.js
@@ -1,0 +1,9 @@
+const express = require("express");
+
+const router = express.Router();
+
+router.get("/", (req, res) => {
+  res.render("inputForm");
+});
+
+module.exports = router;

--- a/routes/testCodes.js
+++ b/routes/testCodes.js
@@ -4,6 +4,9 @@ const convertBlocksToTestCode = require("../middlewares/blockConverter");
 
 const router = express.Router();
 
-router.post("/", convertBlocksToTestCode, async (req, res, next) => {});
+router.post("/", convertBlocksToTestCode, async (req, res, next) => {
+  const { testCode } = res.locals;
+  res.json({ testCode });
+});
 
 module.exports = router;

--- a/routes/testCodes.js
+++ b/routes/testCodes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+
+const convertBlocksToTestCode = require("../middlewares/blockConverter");
+
+const router = express.Router();
+
+router.post("/", convertBlocksToTestCode, async (req, res, next) => {});
+
+module.exports = router;

--- a/views/inputForm.ejs
+++ b/views/inputForm.ejs
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>input 전송 페이지</title>
+</head>
+<body>
+    <h1>input 전송 페이지</h1>
+    <form action="/test-codes" method="POST">
+        <label for="inputData">데이터 입력:</label>
+        <input type="text" id="inputData" name="inputData" required>
+        <button type="submit">보내기</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## 제목

블록 1개를 전달하는 함수 (Wit AI)

## 내용

블록 1개(현재는 input page에서 사용자가 입력한 값)를 wit.ai에게 전달해 해당하는 intent를 가져옵니다.

### input 페이지

<img width="299" alt="image" src="https://github.com/user-attachments/assets/daab95c1-573a-4c0b-8dac-747f206c6ae4">

### wit.ai 응답
![image](https://github.com/user-attachments/assets/be507ed2-4cd8-4046-a151-749db06b7758)

## 항목

- input page(.ejs) 구현
- /input, /test-codes 엔드포인트 및 라우터 설정
- input page에서 입력한 data, wit.ai에게 전달 가능
- 전달된 data에 해당하는 intent 확인 가능

## 특이 사항

- 현재 일정시간 이후 `[nodemon] app crashed - waiting for file changes before starting...`라는 
메시지와 함께 서버 실행이 종료되는 현상이 발생하고 있습니다.
  - 이 부분에 대해선 issues에 올리도록 하겠습니다.
- 블록 2개를 전달하는 상황도 구현 하겠습니다.

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
