### PR TITLE
Refactor: block.js controller 관심사 분리

### DIFF
--- a/utils/assembleTestCodes.js
+++ b/utils/assembleTestCodes.js
@@ -1,0 +1,10 @@
+const assemblePlaywrightTestCodes = (testCode) => {
+  const formattedTestCodes = testCode.join("");
+  return formattedTestCodes
+    .split(";")
+    .filter(Boolean)
+    .map((part) => `await page${part};`)
+    .join("");
+};
+
+module.exports = assemblePlaywrightTestCodes;

--- a/utils/assembleTestCodes.js
+++ b/utils/assembleTestCodes.js
@@ -1,5 +1,6 @@
 const assemblePlaywrightTestCodes = (testCode) => {
   const formattedTestCodes = testCode.join("");
+
   return formattedTestCodes
     .split(";")
     .filter(Boolean)

--- a/utils/convertBlocks.js
+++ b/utils/convertBlocks.js
@@ -1,21 +1,16 @@
 const convertBlocksToNaturalLanguage = (lineBlocks) => {
   return lineBlocks.blockData
     .map((lineBlock) => {
-      let naturalLanguage = "";
-      const blockContents = [];
-
-      lineBlock.blocks.forEach((block) => {
+      const blockContents = lineBlock.blocks.reduce((blockContent, block) => {
         if (block.parameter === "id (#)") {
-          blockContents.push(`id(#) ${block.value}`);
+          blockContent.push(`id(#) ${block.value}`);
         } else if (block.type === "input") {
-          naturalLanguage += `${block.parameter} ${block.value}`;
+          blockContent.push(`${block.parameter} ${block.value}`);
         } else if (block.type === "method") {
-          naturalLanguage += block.method;
-          blockContents.push(naturalLanguage);
-          naturalLanguage = "";
+          blockContent.push(block.method);
         }
-      });
-
+        return blockContent;
+      }, []);
       return blockContents;
     })
     .flat();

--- a/utils/convertBlocks.js
+++ b/utils/convertBlocks.js
@@ -1,0 +1,24 @@
+const convertBlocksToNaturalLanguage = (lineBlocks) => {
+  return lineBlocks.blockData
+    .map((lineBlock) => {
+      let naturalLanguage = "";
+      const blockContents = [];
+
+      lineBlock.blocks.forEach((block) => {
+        if (block.parameter === "id (#)") {
+          blockContents.push(`id(#) ${block.value}`);
+        } else if (block.type === "input") {
+          naturalLanguage += `${block.parameter} ${block.value}`;
+        } else if (block.type === "method") {
+          naturalLanguage += block.method;
+          blockContents.push(naturalLanguage);
+          naturalLanguage = "";
+        }
+      });
+
+      return blockContents;
+    })
+    .flat();
+};
+
+module.exports = convertBlocksToNaturalLanguage;

--- a/utils/convertLanguage.js
+++ b/utils/convertLanguage.js
@@ -1,0 +1,34 @@
+const { Wit } = require("node-wit");
+
+const client = new Wit({
+  accessToken: process.env.WIT_AI_SERVER_ACCESS_TOKEN,
+});
+
+const convertNaturalLanguageToCodes = async (messages) => {
+  const playwrightCodeTemp = messages.map(async (message) => {
+    try {
+      const response = await client.message(message);
+      const intent = response.intents[0]?.name;
+      const entity =
+        response.entities["URL:URL"]?.[0]?.value ||
+        response.entities["attribute:value"]?.[0]?.value;
+
+      if (!intent || !entity) {
+        return "";
+      }
+
+      if (intent === "id") {
+        return `.locator("#${entity}")`;
+      }
+
+      return `.${intent}(${entity});`;
+    } catch (error) {
+      console.error(error);
+      return "";
+    }
+  });
+
+  return Promise.all(playwrightCodeTemp);
+};
+
+module.exports = convertNaturalLanguageToCodes;

--- a/utils/convertLanguage.js
+++ b/utils/convertLanguage.js
@@ -8,13 +8,14 @@ const convertNaturalLanguageToCodes = async (messages) => {
   const playwrightCodeTemp = messages.map(async (message) => {
     try {
       const response = await client.message(message);
-      const intent = response.intents[0]?.name;
+      const { intents, entities } = response;
+      const intent = intents[0]?.name;
       const entity =
-        response.entities["URL:URL"]?.[0]?.value ||
-        response.entities["attribute:value"]?.[0]?.value;
+        entities["URL:URL"]?.[0]?.value ||
+        entities["attribute:value"]?.[0]?.value;
 
       if (!intent || !entity) {
-        return "";
+        return "코드 변환에 실패하였습니다.";
       }
 
       if (intent === "id") {
@@ -24,6 +25,7 @@ const convertNaturalLanguageToCodes = async (messages) => {
       return `.${intent}(${entity});`;
     } catch (error) {
       console.error(error);
+
       return "";
     }
   });


### PR DESCRIPTION
## 제목

Refactor: block.js controller 관심사 분리

## 내용

block.js controller 내부 handleBlocks 함수의 관심사를 분리하였습니다.

## 항목

- 클라이언트 측으로부터 받아온 블록의 데이터를 자연어로 바꿔주는 로직을 수정하였습니다.
- 자연어를 playwright 테스트 코드로 변환해주는 기능을 추가하였습니다.
- 세미콜론을 기준으로 문장 앞에`await page`를 생성시키는 기능을 추가하였습니다.

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
