### PR TITLE
Feat: 메서드 블록을 각 라인 블록의 맨 끝으로 정렬하는 기능 구현

### DIFF
--- a/utils/convertBlocks.js
+++ b/utils/convertBlocks.js
@@ -1,17 +1,41 @@
+const separateMethodBlocks = (blocks) => {
+  const methodBlocks = [];
+  const otherBlocks = [];
+
+  blocks.forEach((block) => {
+    if (block.type === "method") {
+      methodBlocks.push(block);
+    } else {
+      otherBlocks.push(block);
+    }
+  });
+
+  return [...otherBlocks, ...methodBlocks];
+};
+
+const formatNaturalLanguage = (blocks) => {
+  return blocks.reduce(
+    (blockContent, block) => {
+      if (block.parameter === "id (#)") {
+        blockContent.messages.push(`id(#) ${block.value}`);
+      } else if (block.type === "input") {
+        blockContent.accumulatedText += `${block.parameter} ${block.value}`;
+      } else if (block.type === "method") {
+        blockContent.accumulatedText += block.method;
+        blockContent.messages.push(blockContent.accumulatedText);
+        blockContent.accumulatedText = "";
+      }
+      return blockContent;
+    },
+    { accumulatedText: "", messages: [] },
+  ).messages;
+};
+
 const convertBlocksToNaturalLanguage = (lineBlocks) => {
   return lineBlocks.blockData
     .map((lineBlock) => {
-      const blockContents = lineBlock.blocks.reduce((blockContent, block) => {
-        if (block.parameter === "id (#)") {
-          blockContent.push(`id(#) ${block.value}`);
-        } else if (block.type === "input") {
-          blockContent.push(`${block.parameter} ${block.value}`);
-        } else if (block.type === "method") {
-          blockContent.push(block.method);
-        }
-        return blockContent;
-      }, []);
-      return blockContents;
+      const sortedBlocks = separateMethodBlocks(lineBlock.blocks);
+      return formatNaturalLanguage(sortedBlocks);
     })
     .flat();
 };


### PR DESCRIPTION
## 제목
메서드 블록을 각 라인 블록의 맨 끝으로 정렬하는 기능 구현

## 내용

메서드 블록이 맨 뒤에 오지 않으면 자연어 처리를 위해 playwright 메서드 단위로 분할하는 과정이 정상적으로 이루어지지 않았습니다.
메서드 블록이 맨 뒤에 위치하지 않은 채로 post 요청을 보내더라도 Wit AI로 처리하기 전에 요청을 확인해 메서드 블럭이 라인 블럭 내 맨 뒤 순서에 위치하도록 정렬하는 기능을 추가했습니다.

## 항목

- 메서드 블록 정렬 기능
- convertBlocks.js 내부 로직에서 함수 분리해 리팩토링

## 주의 사항

- [x] PR 크기는 300~500줄로 하되 최대 1000줄 미만으로 합니다.
- [x] conflict를 모두 해결하고 PR을 올려주세요

# PR 전 체크리스트

- [x] 가장 최신 브랜치를 pull 하였습니다
- [x] base 브랜치명을 확인하였습니다
- [x] 코드 컨벤션을 모두 확인하였습니다
- [x] 셀프 리뷰를 진행하였습니다.
- [x] 브랜치명을 확인하였습니다.
- [x] 작업 중 dependency 변경사항이 있는 경우 안내해주세요!
